### PR TITLE
Update mcu-swflash-run.sh

### DIFF
--- a/mcu-firmware/alt-method/mcu-swflash-run.sh
+++ b/mcu-firmware/alt-method/mcu-swflash-run.sh
@@ -83,6 +83,7 @@ sudo gpioset gpiochip1 14=0
 
 # Compile the firmware after exiting menuconfig
 echo "Compiling the firmware..."
+make clean
 make
 # Flash the new firmware
 echo "Flashing new firmware to STM32F4..."


### PR DESCRIPTION
Hey Halfmanbear, 

Love all the work you are doing on this along with work on the display can't wait for that.

Just a slight change to the mcu-swflash-run.sh script that adds `make clean` at line 86. This ensures that after pulling a Klipper  repository update it cleans the build files then compiles the firmware as some changes don't cause the make command alone to trigger a rebuild, and instead just reuses the previously compiled firmware.