### PR TITLE
Switch order in overview to flash MCU last

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@
 
 1. Determine stepper motor current & PCB version
 2. Flash eMMC with latest OpenNept4une release image
-3. Run the install script to upgrade / make further settings
-4. (Optional) Flash MCU as [described here](mcu-firmware)
-5. Update third party modules in Kiauh / Fluidd or Mailsail
+3. Run the install script to upgrade and install the latest OpenNept4une printer.cfg
+4. Update third party modules in Kiauh / Fluidd or Mailsail
+5. (Optional) Flash MCU as [described here](mcu-firmware)
 
 **Preparation:**
 


### PR DESCRIPTION
Hey @halfmanbear I noticed that it makes sense to flash the MCU last, after updating Klipper / Klippy through Kiauh frist. I switched that in the README.md