### PR TITLE
Rewrite display communication to use unix socket and expand feature set

### DIFF
--- a/display/display.py
+++ b/display/display.py
@@ -301,7 +301,7 @@ class DisplayController:
             "extruder": ["temperature"],
             "heater_generic heater_bed_outer": ["temperature"],
             "display_status": ["progress"],
-            "print_stats": ["state", "print_duration", "filename"],
+            "print_stats": ["state", "print_duration", "filename", "total_duration"],
             "output_pin Part_Light": ["value"],
             "output_pin Frame_Light": ["value"],
             "configfile": ["config"],
@@ -461,6 +461,10 @@ class DisplayController:
                 else:
                     if len(self.history) == 0 or self.history[-1] in PRINTING_PAGES:
                         self._navigate_to_page(f'page 1')
+
+            if "display_status" in new_data and "progress" in new_data["display_status"] and "print_duration" in new_data["print_stats"]:
+                total_time = new_data["print_stats"]["print_duration"] / new_data["display_status"]["progress"]
+                self._write(f'p[19].b[37].txt="{format_time(total_time - new_data["print_stats"]["print_duration"])}"')
 
         if "output_pin Part_Light" in new_data:
             self.part_light_state = int(new_data["output_pin Part_Light"]["value"]) == 1

--- a/display/display.py
+++ b/display/display.py
@@ -1,207 +1,506 @@
+import json
+import pathlib
+import sys
+import serial_asyncio
 import serial
 import time
-import moonrakerpy as moonpy
 import re
 import threading
+import socket
+import os, os.path
+import asyncio
+import traceback
 
-from response_actions import response_actions
+from response_actions import response_actions, response_errors
 
-class NavigationController:
-    def __init__(self, printer, serial_device):
-        self.history = ["page 1"]
-        self.printer = printer
-        self.serial_device = serial_device
+def format_temp(value):
+    if value is None:
+        return "N/A"
+    return f"{value:3.1f}°C"
+
+def format_time(seconds):
+    if seconds is None:
+            return "N/A"
+    if seconds < 3600:
+        return time.strftime("%Mm %Ss", time.gmtime(seconds))
+    return time.strftime("%Hh %Mm", time.gmtime(seconds))
+
+def format_percent(value):
+    if value is None:
+        return "N/A"
+    return f"{value * 100:2.0f}%"
+
+class MappingLeaf:
+    def __init__(self, fields, field_type="txt", formatter=None):
+        self.fields = fields
+        self.field_type = field_type
+        self.formatter = formatter
+
+    def format(self, value):
+        if self.formatter is not None:
+            return self.formatter(value)
+        if isinstance(value, float):
+            return f"{value:3.2f}"
+        return str(value)
+
+DATA_MAPPING = {
+    "extruder": {
+        "temperature": [MappingLeaf(["p[1].nozzletemp", "p[6].nozzletemp", "p[19].nozzletemp"], formatter=format_temp)]
+    },
+    "heater_bed": {
+        "temperature": [MappingLeaf(["p[1].bedtemp", "p[6].bedtemp", "p[19].bedtemp"], formatter=format_temp)]
+    },
+    "heater_generic heater_bed_outer": {
+        "temperature": [MappingLeaf(["p[1].out_bedtemp", "p[6].out_bedtemp"], formatter=format_temp)]
+    },
+    "motion_report": {
+        "live_position": {
+            0: [MappingLeaf(["p[1].x_pos"]), MappingLeaf(["p[19].x_pos"], formatter=lambda x: f"X[{x:3.2f}]")],
+            1: [MappingLeaf(["p[1].y_pos"]), MappingLeaf(["p[19].y_pos"], formatter=lambda y: f"Y[{y:3.2f}]")],
+            2: [MappingLeaf(["p[1].z_pos", "p[19].b[33]"])],
+        },
+        "live_velocity": [MappingLeaf(["p[19].b[34]"], formatter=lambda x: f"{x:3.2f}mm/s")],
+    },
+    "print_stats": {
+        "print_duration": [MappingLeaf(["p[19].b[6]"], formatter=format_time)],
+        "filename": [MappingLeaf(["p[19].b[5]"])],
+    },
+    "gcode_move": {
+        "extrude_factor": [MappingLeaf(["p[19].b[35]"], formatter=format_percent)],
+        "speed_factor": [MappingLeaf(["p[19].b[9]"], formatter=format_percent)],
+    },
+    "fan": {
+        "speed": [MappingLeaf(["p[19].b[10]"], formatter=format_percent), MappingLeaf(["p[11].b[12]"], field_type="pic", formatter=lambda x: "77" if int(x) == 1 else "76")]
+    },
+    "display_status": {
+        "progress": [MappingLeaf(["p[19].b[17]"], formatter=lambda x: f"{x * 100:2.1f}")]
+    },
+    "output_pin Part_Light": {"value": [MappingLeaf(["p[84].led1"], field_type="pic", formatter=lambda x: "77" if int(x) == 1 else "76")]},
+    "output_pin Frame_Light": {"value": [MappingLeaf(["p[84].led2"], field_type="pic", formatter= lambda x: "77" if int(x) == 1 else "76")]},
+    "filament_switch_sensor fila": {"enabled": [MappingLeaf(["p[11].b[11]"], field_type="pic", formatter= lambda x: "77" if int(x) == 1 else "76")]}
+}
+
+PRINTING_PAGES = [
+    "page 19",
+    "page 27",
+    "page 127",
+    "page 135",
+    "page 106",
+    "page 25",
+    "page 26",
+    "page 84",
+]
+
+TABBED_PAGES = [
+    "page 6",
+    "page 8",
+    "page 9",
+    "page 27",
+    "page 28",
+    "page 29",
+    "page 30",
+]
+
+MODEL_REGULAR = 0
+MODEL_PRO = 1
+MODEL_PLUS = 2
+MODEL_MAX = 3
+
+BACKGROUND_GRAY = 10665
+
+SOCKET_LIMIT = 20 * 1024 * 1024
+class DisplayController:
+
+    def __init__(self):
+        self.connected = False
         self.part_light_state = False
         self.frame_light_state = False
         self.fan_state = False
         self.filament_sensor_state = False
+        self.move_distance = '1'
+        self.z_offset_distance = '0.1'
+        self.out_fd = sys.stdout.fileno()
+        os.set_blocking(self.out_fd, False)
+        self.pending_req = {}
+        self.pending_reqs = {}
+        self.history = []
+        padding = [0xFF, 0xFF, 0xFF]
+        self.serial_padding = serial.to_bytes(padding)
 
-    def start_continuous_update(self):
-        def update_loop():
-            time.sleep(3)
-            while True:
-                if self.history[-1] == "page 1":
-                    self.update_if_page1(print_to_terminal=False)
-                time.sleep(0.5)
+        self.printer_model = MODEL_REGULAR
 
-        self.update_thread = threading.Thread(target=update_loop)
-        self.update_thread.daemon = True
-        self.update_thread.start()
+        self.printable_files = []
+        self.files_page = 0
 
-    def update_if_page1(self, print_to_terminal=False):
-        temps = self.printer.query_temperatures()
-        extruder = temps['extruder']['temperature']
-        bed = temps['heater_bed']['temperature']
-#        outbed = temps.get('heater_generic heater_bed_outer', {}).get('temperature', 'N/A')
-        toolhead = self.printer.query_status('toolhead')
-        x_pos = toolhead['position'][0]
-        y_pos = toolhead['position'][1]
-        z_pos = toolhead['position'][2]
-        self._write(f'nozzletemp.txt="{extruder}°C"', print_to_terminal)
-        self._write(f'bedtemp.txt="{bed}°C"', print_to_terminal)
-#        self._write(f'out_bedtemp.txt="{outbed}°C"', print_to_terminal)
-        self._write(f'x_pos.txt="{x_pos}"', print_to_terminal)
-        self._write(f'y_pos.txt="{y_pos}"', print_to_terminal)
-        self._write(f'z_pos.txt="{z_pos}"', print_to_terminal)
+    def get_device_name(self):
+        if self.printer_model == MODEL_REGULAR:
+            return "Neptune 4"
+        elif self.printer_model == MODEL_PRO:
+            return "Neptune 4 Pro"
+        elif self.printer_model == MODEL_PLUS:
+            return "Neptune 4 Plus"
+        elif self.printer_model == MODEL_MAX:
+            return "Neptune 4 Max"
+        return "Unknown"
 
-    def _navigate_to_page(self, page):
-        if self.history[-1] != page:
-            self.history.append(page)
-            self._change_display(page)
-            print(f"Navigate to {page}. Current history: {self.history}")
+    def initialize_display(self):
+        if self.printer_model == MODEL_REGULAR:
+            self._write(f'p[1].q4.picc=213') # 213=N4
+        elif self.printer_model == MODEL_PRO:
+            self._write(f'p[1].q4.picc=214') #214=N4Pro
+            self._write(f'p[1].disp_q5.val=1') # N4Pro Outer Bed Symbol (Bottom Rig>
+            self._write(f'vis out_bedtemp,1') # Only N4Pro
 
-    def printer_status(self):
-        temps = self.printer.query_temperatures()
-        extruder = temps['extruder']['temperature']
-        bed = temps['heater_bed']['temperature']
-#        outbed = temps['heater_generic heater_bed_outer']['temperature']
-        toolhead = self.printer.query_status('toolhead')
-        x_pos = toolhead['position'][0]
-        y_pos = toolhead['position'][1]
-        z_pos = toolhead['position'][2]
-        self._write(f'main.q4.picc=213') # 213=N4 214=N4Pro
-        self._write(f'main.disp_q5.val=1') # N4Pro Outer Bed Symbol (Bottom Rig>
-        self._write(f'page 1')
-        self._write(f'vis q5,1')
-        self._write(f'vis out_bedtemp,1') # Only N4Pro
-        self._write(f'page 109')
-        self._write(f'page 1')
-        self._write(f'nozzletemp.txt="{extruder}°C"')
-        self._write(f'bedtemp.txt="{bed}°C"')
-#        self._write(f'out_bedtemp.txt="{outbed}°C"')
-        self._write(f'x_pos.txt="{x_pos}"')
-        self._write(f'y_pos.txt="{y_pos}"')
-        self.update_if_page1()
+
+        self._write(f'p[35].b[8].txt="{self.get_device_name()}"')
+
+    def send_gcode(self, gcode):
+        self._loop.create_task(self._send_moonraker_request("printer.gcode.script", {"script": gcode}))
 
     def move_axis(self, axis, distance):
-        self.printer.send_gcode('G91')  # Set to relative positioning
-        self.printer.send_gcode(f'G1 {axis}{distance}')  # Move axis
-        self.printer.send_gcode('G90')  # Set back to absolute positioning
+        self.send_gcode(f'G91\nG1 {axis}{distance}\nG90')
+
+    def special_page_handling(self):
+        if len(self.history) > 0:
+            if self.history[-1] == "page 35":
+                self._write('fill 0,400,320,60,' + str(BACKGROUND_GRAY))
+                self._write('xstr 0,400,320,30,1,65535,' + str(BACKGROUND_GRAY) + ',1,1,1,"OpenNept4une"')
+                self._write('xstr 0,430,320,30,2,GRAY,' + str(BACKGROUND_GRAY) + ',1,1,1,"github.com/halfmanbear/OpenNept4une"')
+
+    def _navigate_to_page(self, page):
+        if len(self.history) == 0 or self.history[-1] != page:
+            if page in TABBED_PAGES and self.history[-1] in TABBED_PAGES:
+                self.history[-1] = page
+            else:
+                self.history.append(page)
+            self._write(page)
+            print(f"Navigate to {page}. Current history: {self.history}")
+
+            self.special_page_handling()
 
     def execute_action(self, action):
         if action.startswith("move_"):
             parts = action.split('_')
             axis = parts[1].upper()
-            distance = parts[2]
-            self.move_axis(axis, distance)
+            direction = parts[2]
+            self.move_axis(axis, direction + self.move_distance)
+        elif action.startswith("set_distance_"):
+            parts = action.split('_')
+            self.move_distance = parts[2]
+        if action.startswith("zoffset_"):
+            parts = action.split('_')
+            direction = parts[2]
+            #self.move_axis(axis, direction + self.z_offset_distance)
+        elif action.startswith("zoffsetchange_"):
+            parts = action.split('_')
+            self.z_offset_distance = parts[2]
         elif action == "toggle_part_light":
-            self._toggle_light("Part_Light", self.part_light_state)
             self.part_light_state = not self.part_light_state
+            self._set_light("Part_Light", self.part_light_state)
         elif action == "toggle_frame_light":
-            self._toggle_light("Frame_Light", self.frame_light_state)
             self.frame_light_state = not self.frame_light_state
+            self._set_light("Frame_Light", self.frame_light_state)
         elif action == "toggle_filament_sensor":
-            self._toggle_filament_sensor()
-        elif action == "toggle_fan_ON":
-            self._toggle_fan(True)
-        elif action == "toggle_fan_OFF":
-            self._toggle_fan(False)
+            self.filament_sensor_state = not self.filament_sensor_state
+            self._toggle_filament_sensor(self.filament_sensor_state)
+        elif action == "toggle_fan":
+            self.fan_state = not self.fan_state
+            self._toggle_fan(self.fan_state)
         elif action.startswith("printer.send_gcode"):
             gcode = action.split("'")[1]
-            self.printer.send_gcode(gcode)
+            self._loop.create_task(self._send_moonraker_request("printer.gcode.script", {"script": gcode}))
         elif action == "go_back":
             self._go_back()
         elif action.startswith("page"):
             self._navigate_to_page(action)
+        elif action == "emergency_stop":
+            self._loop.create_task(self._send_moonraker_request("printer.emergency_stop"))
+        elif action == "pause_print":
+            self._go_back()
+            self._write(f'p[19].b[44]].pic=69')
+            self._loop.create_task(self._send_moonraker_request("printer.print.pause"))
+        elif action == "stop_print":
+            self._go_back()
+            self._navigate_to_page('page 130')
+            self._loop.create_task(self._send_moonraker_request("printer.print.stop"))
+        elif action == "resume_print":
+            self._go_back()
+            self._write(f'p[19].b[44]].pic=68')
+            self._loop.create_task(self._send_moonraker_request("printer.print.resume"))
+        elif action == "files_picker":
+            self._navigate_to_page(f'page 2')
+            self._loop.create_task(self._load_files())
+        elif action.startswith("files_page_"):
+            parts = action.split('_')
+            direction = parts[2]
+            self.files_page = int(max(0, min((len(self.printable_files)/5) - 1, self.files_page + (1 if direction == 'next' else -1))))
+            self.show_files_page()
+        elif action.startswith("open_file_"):
+            parts = action.split('_')
+            index = int(parts[2])
+            self.active_file = self.printable_files[(self.files_page * 5) + index]
+            self._navigate_to_page(f'page 18')
+            self._write(f'p[18].b[2].txt="{self.active_file["path"]}"')
+        elif action == "print_opened_file":
+            self._go_back()
+            self._navigate_to_page('page 130')
+            self._loop.create_task(self._send_moonraker_request("printer.print.start", {"filename": self.active_file["path"]}))
 
-    def _toggle_light(self, light_name, current_state):
-        new_state = not current_state
+    def _write(self, data):
+        #print(f"<= {data}")
+        message = str.encode(data)
+        self.serial_writer.write(message)
+        self.serial_writer.write(self.serial_padding)
+
+    def _set_light(self, light_name, new_state):
         gcode = f"{light_name}_{'ON' if new_state else 'OFF'}"
-        self.printer.send_gcode(gcode)
-        self._update_light_visual(light_name, new_state)
+        self.send_gcode(gcode)
 
-    def _update_light_visual(self, light_name, state):
-        pic_value = '77' if state else '76'
-        if light_name == "Part_Light":
-            self._write(f'led.led1.pic={pic_value}')
-        elif light_name == "Frame_Light":
-            self._write(f'led.led2.pic={pic_value}')
+    def _toggle_filament_sensor(self, state):
+        gcode = f"SET_FILAMENT_SENSOR SENSOR=fila ENABLE={'1' if state else '0'}"
+        self.send_gcode(gcode)
 
-    def _toggle_filament_sensor(self):
-        new_state = not self.filament_sensor_state
-        gcode = f"SET_FILAMENT_SENSOR SENSOR=fila ENABLE={'0' if new_state else '1'}"
-        self.printer.send_gcode(gcode)
-        self.filament_sensor_state = new_state
-        self._update_filament_visual(new_state)
-
-    def _update_filament_visual(self, state):
-        filament_value = '76' if state else '77'
-        self._write(f'filamentdec.pic={filament_value}')
 
     def _toggle_fan(self, state):
         gcode = f"M106 S{'255' if state else '0'}"
-        self.printer.send_gcode(gcode)
-        self.fan_state = state
-        self._write(f"fanstatue.pic={'77' if state else '76'}")
+        self.send_gcode(gcode)
+
+    async def _load_files(self):
+        self.printable_files = (await self._send_moonraker_request("server.files.list"))["result"]
+        self.show_files_page()
+
+    def show_files_page(self):
+        page_size = 5
+        self._write(f'p[2].b[11].txt="Files ({(self.files_page * page_size) + 1}-{(self.files_page * page_size) + page_size}/{len(self.printable_files)})"')
+        component_index = 0
+        for index in range(self.files_page * page_size, min(len(self.printable_files), (self.files_page + 1) * page_size)):
+            file = self.printable_files[index]
+            self._write(f'p[2].b[{component_index + 18}].txt="{file["path"]}"')
+            component_index += 1
 
     def _go_back(self):
         if len(self.history) > 1:
             self.history.pop()
             back_page = self.history[-1]
-            self._change_display(back_page)
+            self._write(back_page)
         else:
             print("Already at the main page.")
 
-    def _change_display(self, page):
-        self._write(page)
+    def start_listening(self):
+        loop.create_task(self.listen())
 
-    def _write(self, data, print_to_terminal=True):
-        if print_to_terminal:
-            print(f"Write {data}")
-        padding = [0xFF, 0xFF, 0xFF]
-        self.serial_device.write(str.encode(data))
-        self.serial_device.write(serial.to_bytes(padding))
+    async def listen(self):
+        self.serial_reader, self.serial_writer = await serial_asyncio.open_serial_connection(url='/dev/ttyS1', baudrate=115200)
+        self._loop.create_task(self._process_serial(self.serial_reader))
+        await self._connect()
+        ret = await self._send_moonraker_request("printer.objects.subscribe", {"objects": {
+            "gcode_move": ["extrude_factor", "speed_factor"],
+            "motion_report": ["live_position", "live_velocity"],
+            "fan": ["speed"],
+            "heater_bed": ["temperature"],
+            "extruder": ["temperature"],
+            "heater_generic heater_bed_outer": ["temperature"],
+            "display_status": ["progress"],
+            "print_stats": ["state", "print_duration", "filename"],
+            "output_pin Part_Light": ["value"],
+            "output_pin Frame_Light": ["value"],
+            "configfile": ["config"],
+            "filament_switch_sensor fila": ["enabled"]
+        }})
+        data = ret["result"]["status"]
+        if "temperature" in data["heater_generic heater_bed_outer"] and data["heater_generic heater_bed_outer"]["temperature"] is not None:
+            self.printer_model = MODEL_PRO
+        print("Printer Model:", self.printer_model)
+        self.initialize_display()
+        self.handle_status_update(data)
 
-def generate_key(readData):
-    return ''.join(readData)
+    async def _send_moonraker_request(
+        self, method, params={}):
+        message = self._make_rpc_msg(method, **params)
+        fut = self._loop.create_future()
+        self.pending_reqs[message["id"]] = fut
+        data = json.dumps(message).encode() + b"\x03"
+        try:
+            self.writer.write(data)
+            await self.writer.drain()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            await self.close()
+        return await fut
 
-def match_key(pattern, key):
-    return re.match(pattern.replace('??', '..'), key) is not None
+    def _find_ips(self, network):
+        ips = []
+        for key in network:
+            if "ip_addresses" in network[key]:
+                for ip in network[key]["ip_addresses"]:
+                    if ip["family"] == "ipv4":
+                        ips.append(ip["address"])
+        return ips
 
-def handle_response(readData, nav_controller):
-    action_key = generate_key(readData)
-    for key in response_actions.keys():
-        if match_key(key, action_key):
-            nav_controller.execute_action(response_actions[key])
+    async def _connect(self) -> None:
+        sockfile = "/home/mks/printer_data/comms/moonraker.sock"
+        sockpath = pathlib.Path(sockfile).expanduser().resolve()
+        print(f"Connecting to Moonraker at {sockpath}")
+        while True:
+            try:
+                reader, writer = await asyncio.open_unix_connection(
+                    sockpath, limit=SOCKET_LIMIT
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                await asyncio.sleep(1.)
+                continue
             break
-    else:
-        print("No action for response:", readData)
+        self.writer = writer
+        self._loop.create_task(self._process_stream(reader))
+        self.connected = True
+        print("Connected to Moonraker")
+        ret = await self._send_moonraker_request("server.connection.identify", {
+                "client_name": "OpenNept4une Display Connector",
+                "version": "0.0.1",
+                "type": "other",
+                "url": "https://github.com/halfbearman/opennept4une"
+            })
+        print(f"Client Identified With Moonraker: {ret}")
 
-printer = moonpy.MoonrakerPrinter('http://127.0.0.1')
-ser = serial.Serial("/dev/ttyS1", 115200, timeout=2, writeTimeout=0)
+        system = (await self._send_moonraker_request("machine.system_info"))["result"]["system_info"]
+        self._write("p[35].b[16].txt=\"" + ", ".join(self._find_ips(system["network"])) + "\"")
+        software_version = (await self._send_moonraker_request("printer.info"))["result"]["software_version"]
+        self._write("p[35].b[10].txt=\"" + software_version.split("-")[0] + "\"")
 
-nav_controller = NavigationController(printer, ser)
-nav_controller.start_continuous_update()
+    def _make_rpc_msg(self, method: str, **kwargs):
+        msg = {"jsonrpc": "2.0", "method": method}
+        uid = id(msg)
+        msg["id"] = uid
+        self.pending_req = msg
+        if kwargs:
+            msg["params"] = kwargs
+        return msg
+    
+    def generate_key(self, readData):
+        return ''.join(readData)
 
-print('Starting Up...')
+    def match_key(self, pattern, key):
+        return re.match(pattern.replace('??', '..'), key) is not None
+
+    def handle_response(self, readData):
+        action_key = self.generate_key(readData)
+        for key in response_actions.keys():
+            if self.match_key(key, action_key):
+                self.execute_action(response_actions[key])
+                break
+        else:
+            for key in response_errors.keys():
+                if self.match_key(key, action_key):
+                    print("Error:", response_errors[key])
+                    return
+            print("No action for response:", readData)
+
+    async def _process_serial(self, reader):
+        while True:
+            data = await reader.readuntil(self.serial_padding)
+            message = data.rstrip().hex()
+            print(f"=> {message}")
+            self.handle_response(message)
+
+    
+    async def _process_stream(
+        self, reader: asyncio.StreamReader
+    ) -> None:
+        errors_remaining: int = 10
+        while not reader.at_eof():
+            try:
+                data = await reader.readuntil(b'\x03')
+                decoded = data[:-1].decode(encoding="utf-8")
+                item = json.loads(decoded)
+            except (ConnectionError, asyncio.IncompleteReadError):
+                break
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                errors_remaining -= 1
+                if not errors_remaining or not self.connected:
+                    break
+                continue
+            errors_remaining = 10
+            if "id" in item:
+                fut = self.pending_reqs.pop(item["id"], None)
+                if fut is not None:
+                    fut.set_result(item)
+            elif item["method"] == "notify_status_update":
+                self.handle_status_update(item["params"][0])
+        print("Unix Socket Disconnection from _process_stream()")
+        await self.close()
+
+    def handle_config_change(self, new_data):
+        max_x, max_y, max_z = 0, 0, 0
+        if "config" in new_data:
+            if "stepper_x" in new_data["config"]:
+                if "position_max" in new_data["config"]["stepper_x"]:
+                    max_x = int(new_data["config"]["stepper_x"]["position_max"])
+            if "stepper_y" in new_data["config"]:
+                if "position_max" in new_data["config"]["stepper_x"]:
+                    max_y = int(new_data["config"]["stepper_y"]["position_max"])
+            if "stepper_z" in new_data["config"]:
+                if "position_max" in new_data["config"]["stepper_x"]:
+                    max_z = int(new_data["config"]["stepper_z"]["position_max"])
+
+            if max_x > 0 and max_y > 0 and max_z > 0:
+                self._write(f'p[35].b[9].txt="{max_x}x{max_y}x{max_z}"')
+
+    def handle_status_update(self, new_data, data_mapping=DATA_MAPPING):
+        if "print_stats" in new_data:
+            if "state" in new_data["print_stats"]:
+                print(f"Status Update: {new_data['print_stats']['state']}")
+                if new_data["print_stats"]["state"] != "standby":
+                    print(self.history)
+                    if len(self.history) == 0 or self.history[-1] not in PRINTING_PAGES:
+                        self._navigate_to_page(f'page 19')
+                else:
+                    if len(self.history) == 0 or self.history[-1] in PRINTING_PAGES:
+                        self._navigate_to_page(f'page 1')
+
+        if "output_pin Part_Light" in new_data:
+            self.part_light_state = int(new_data["output_pin Part_Light"]["value"]) == 1
+        if "output_pin Frame_Light" in new_data:
+            self.part_light_state = int(new_data["output_pin Frame_Light"]["value"]) == 1
+        if "fan" in new_data:
+            self.fan_state = int(new_data["fan"]["speed"]) > 0
+        if "filament_switch_sensor fila" in new_data:
+            self.filament_sensor_state = int(new_data["filament_switch_sensor fila"]["enabled"]) == 1
+        if "configfile" in new_data:
+            self.handle_config_change(new_data["configfile"])
+        is_dict = isinstance(new_data, dict)
+        for key in new_data if is_dict else range(len(new_data)):
+            if key in data_mapping:
+                value = new_data[key]
+                mapping_value = data_mapping[key]
+                if isinstance(mapping_value, dict):
+                    self.handle_status_update(value, mapping_value)
+                elif isinstance(mapping_value, list):
+                    for mapping_leaf in mapping_value:
+                        for mapped_key in mapping_leaf.fields:
+                            if mapping_leaf.field_type == "txt":
+                                self._write(f'{mapped_key}.{mapping_leaf.field_type}="{mapping_leaf.format(value)}"')
+                            else:
+                                self._write(f'{mapped_key}.{mapping_leaf.field_type}={mapping_leaf.format(value)}')
+
+    async def close(self):
+        if not self.connected:
+            return
+        self.connected = False
+        self.writer.close()
+        await self.writer.wait_closed()
+
 
 try:
-    ser.close()
-    ser.open()
-
-    nav_controller.execute_action("page 109")
-    nav_controller.printer_status()
-    nav_controller.execute_action("page 1")
-
-    while True:
-        print("Waiting for user interaction from Display (Ctrl-C to navigate)")
-        readData = []
-        try:
-            while True:
-                response = ser.read()
-                if response:
-                    readData.append(response.hex())
-                    if len(readData) >= 6:
-                        print("Data read from Display: " + ''.join(readData))
-                        handle_response(readData, nav_controller)
-                        break
-                else:
-                    time.sleep(0.2)
-        except KeyboardInterrupt:
-            print("\nEnter page number to navigate to (e.g., 'page 1', 'page 2', etc.): ")
-            page = input().strip()
-            nav_controller.execute_action(page)
+    loop = asyncio.get_event_loop()
+    controller = DisplayController()
+    controller._loop = loop
+    loop.call_later(1, controller.start_listening)
+    loop.run_forever()
 except Exception as e:
     print("Error communicating...: " + str(e))
-finally:
-    ser.close()
+    print(traceback.format_exc())

--- a/display/response_actions.py
+++ b/display/response_actions.py
@@ -1,22 +1,37 @@
 response_actions = {
+    '651200ffffff': "print_opened_file", # Confirm Print File
+    '651300ffffff': "page 27", # Printing Page > Settings
+    '651302ffffff': "pause_print", # Printing Page > Confirm Pause
+    '651a00ffffff': "stop_print", # Printing Page > Confirm Stop
     '65??00ffffff': "go_back",  # Return to Previous Page
     # MAIN PAGE OPTIONS (page 1)
-    '650101ffffff': "page 2",  # Page 1 > Print Files Page 1
+    '650101ffffff': "files_picker",  # Page 1 > Print Files Page 1
     '650102ffffff': "page 8",  # Page 1 > Prepare Page (Move)
     '650103ffffff': "page 11", # Page 1 > Settings Page
     '650104ffffff': "page 14", # Page 1 > Level Page
     # PRINT PAGE OPTIONS
-    '650202ffffff': "page 3",  # Next Page Print Files ->
-    '650201ffffff': "page 2",  # Previous Print Files Page <-
+    '650202ffffff': "files_page_next",  # Next Page Print Files ->
+    '650201ffffff': "files_page_prev",  # Previous Print Files Page <-
+    '650207ffffff': "open_file_0",  # Print Files Page > Print File 0
+    '650208ffffff': "open_file_1",  # Print Files Page > Print File 1
+    '650209ffffff': "open_file_2",  # Print Files Page > Print File 2
+    '65020affffff': "open_file_3",  # Print Files Page > Print File 3
+    '65020bffffff': "open_file_4",  # Print Files Page > Print File 4
     # PREPARE PAGE OPTIONS
     '65080cffffff': "printer.send_gcode('G28')", # Home Printer > Moonraker command
-    '650808ffffff': "move_x_1mm", # X+ 1mm
-    '650809ffffff': "move_x_-1mm", # X- 1mm
-    '65080affffff': "move_y_1mm", # Y+ 1mm
-    '650807ffffff': "move_y_-1mm", # Y- 1mm
-    '650806ffffff': "move_z_1mm", # Z+ 1mm
-    '65080bffffff': "move_z_-1mm", # Z- 1mm
-    '650803ffffff': "page 10mm", # 10mm Move Page
+    '65080dffffff': "printer.send_gcode('G28 Z')", # Home Z Axis > Moonraker command
+    '650805ffffff': "printer.send_gcode('G28 Y')", # Home Y Axis > Moonraker command
+    '650804ffffff': "printer.send_gcode('G28 X')", # Home X Axis > Moonraker command
+    '65080effffff': "printer.send_gcode('M84')", # Disable Motors > Moonraker command
+    '650808ffffff': "move_x_+", # X+ 1mm
+    '650809ffffff': "move_x_-", # X- 1mm
+    '65080affffff': "move_y_+", # Y+ 1mm
+    '650807ffffff': "move_y_-", # Y- 1mm
+    '650806ffffff': "move_z_+", # Z+ 1mm
+    '65080bffffff': "move_z_-", # Z- 1mm
+    '650801ffffff': 'set_distance_0.1', # 0.1mm Move Page
+    '650802ffffff': "set_distance_1", # 1mm Move Page
+    '650803ffffff': "set_distance_10", # 10mm Move Page
     '65080fffffff': "page 6",  # Prepare Page (Move) > Prepare Page (Temp)
     '650607ffffff': "page 8",  # Prepare Page (Temp) > Prepare Page (Move)
     '650608ffffff': "page 9",  # Prepare Page (Temp) > Prepare Page (Extruder)
@@ -30,6 +45,10 @@ response_actions = {
     '652003ffffff': "page 33", # Temperature Settings > PETG
     '652004ffffff': "page 33", # Temperature Settings > TPU
     '652005ffffff': "page 33", # Temperature Settings > LEVEL
+    '652104ffffff': 'temp_extruder_down', # Temperature Settings > MATERIAL > Extruder Temp Down
+    '652105ffffff': 'temp_extruder_up', # Temperature Settings > MATERIAL > Extruder Temp Up
+    '652106ffffff': 'temp_bed_down', # Temperature Settings > MATERIAL > Bed Temp Down
+    '652107ffffff': 'temp_bed_up', # Temperature Settings > MATERIAL > Bed Temp Up
     # ABOUT MACHINE
     '650b08ffffff': "page 35", # Settings Page > About Machine
     # ADVANCED SETTINGS
@@ -39,7 +58,7 @@ response_actions = {
     '655401ffffff': "toggle_part_light", # Light Control > Part Light toggle
     '655402ffffff': "toggle_frame_light", # Light Control > Frame Light toggle
     # FAN CONTROL
-    '5aa50683103e': "toggle_fan_ON", # Settings Page > Fan Control Toggle printer.send_gcode('M106 S255')
+    '5aa50683103e010007650b04ffffff': "toggle_fan", # Settings Page > Fan Control Toggle printer.send_gcode('M106 S255')
     'ffffff5aa506': "toggle_fan_OFF", # Settings Page > Fan Control Toggle printer.send_gcode('M106 S0')
     # MOTORS OFF
     '650b05ffffff': "printer.send_gcode('M84')", # Settings Page > Motor-off
@@ -47,4 +66,38 @@ response_actions = {
     '650b06ffffff': "toggle_filament_sensor", # Settings Page > Filament Detector Toggle
     # FACTORY SETTINGS
     '650b07ffffff': "factorysettingspage", # Settings Page > Factory Settings
+
+    # PRINTING SCREEN
+    '651304ffffff': "page 106", # Printing Page > Halt
+    '651301ffffff': "page 25", # Printing Page > Pause
+    '651302ffffff': "page 26", # Printing Page > Stop
+    '651303ffffff': "page 84", # Printing Page > LED Control
+
+
+    '65??09ffffff': "page 27", # Printing Page > Filament
+    '65??0affffff': "page 135", # Printing Page > Speed
+    '651b0cffffff': "page 135", # Printing Page > Speed
+    '65??0dffffff': "page 127", # Printing Page > Adjust
+
+    '657f07ffffff': "page 84", # Printing Page > Adjust > LED Control
+    '657f08ffffff': "toggle_filament_sensor", # Printing Page > Adjust > Filament Sensor Toggle
+    # '657f06ffffff': "toggle_speed_adaptive", # Printing Page > Adjust > Adaptive Speed Toggle
+    '657f04ffffff': "zoffset_+", # Printing Page > Adjust > Z Offset Up
+    '657f05ffffff': "zoffset_-", # Printing Page > Adjust > Z Offset Down
+    '657f01ffffff': 'zoffsetchange_0.1', # Printing Page > Adjust > Z Offset Change 0.1mm
+    '657f02ffffff': 'zoffsetchange_1', # Printing Page > Adjust > Z Offset Change 1mm
+    '657f03ffffff': 'zoffsetchange_10', # Printing Page > Adjust > Z Offset Change 10mm
+}
+
+response_errors = {
+    '00ffffff': 'Invalid Instruction',
+    '02ffffff': 'Invalid Component ID',
+    '03ffffff': 'Invalid Page ID',
+    '04ffffff': 'Invalid Picture ID',
+    '05ffffff': 'Invalid Font ID',
+    '11ffffff': 'Invalid Baud Rate',
+    '1affffff': "Invalid Variable name or attribute",
+    '1bffffff': "Invalid Variable operation",
+    '1cffffff': "Assignment failed to assign",
+    '1effffff': "Invalid Quantity of Parameters",
 }


### PR DESCRIPTION
As the title says, I rewrote large parts of the script to use the moon raker unix socket instead. this allows us to subscribe to updates instead of having to query them. Big performance improvement and also makes data displayed more real time. Moonraker only sends data that has changed with its notifications. I wrote a simple mapping system that iterates through the new data and assigns it to all appropriate fields. This means that p.e. the main screen data is also updated when a different screen is shown. A lot of the updates that happen during printing that update the main screen technically are not necessary, but a) this doesn't seem to affect performance and b) this way the main screen is always up to date whenever it is shown again.

Things that now work

- Live updating data on main screen
- Updating fan, filament sensor and light switches through data received by moonraker to prevent inconsistent states
- Populated About screen (I also hid the update button and added a reference to this repo instead, since the update button does not work anyway)
- Live updating printing screen that displays and hides automatically
- LED controls
- pausing/resuming/stopping print (this might still be a bit wonky)
- Print screen lists files from moonraker and allows them to be selected for printing
- Some more navigation between screens

What doesn't work: 
- Most of everything else