### PR TITLE
fix: typo on ANDROID_RULE_INSTALLER

### DIFF
--- a/OpenNept4une.sh
+++ b/OpenNept4une.sh
@@ -136,7 +136,7 @@ android_rules() {
         echo "Running ADB Rule Installer..."
         if [ -f "$ANDROID_RULE_INSTALLER" ]; then
             chmod +x "$ANDROID_RULE_INSTALLER"
-            "$ANDROIF_RULE_INSTALLER"
+            "$ANDROID_RULE_INSTALLER"
         else
             echo "Error: Android rule installer script not found."
         fi


### PR DESCRIPTION
The script was not triggering the patch due to a small typo. It works fine now!