### PR TITLE
Improvements to print and file handling for display

### DIFF
--- a/display/display.py
+++ b/display/display.py
@@ -70,7 +70,7 @@ DATA_MAPPING = {
     },
     "print_stats": {
         "print_duration": [MappingLeaf(["p[19].b[6]"], formatter=format_time)],
-        "filename": [MappingLeaf(["p[19].t0"])],
+        "filename": [MappingLeaf(["p[19].t0"], formatter=lambda x: x.replace(".gcode", ""))],
     },
     "gcode_move": {
         "extrude_factor": [MappingLeaf(["p[19].flow_speed"], formatter=format_percent)],

--- a/display/display.py
+++ b/display/display.py
@@ -469,7 +469,14 @@ class DisplayController:
 
     def show_files_page(self):
         page_size = 5
-        self._write(f'p[2].b[11].txt="Files ({(self.files_page * page_size) + 1}-{(self.files_page * page_size) + page_size}/{len(self.dir_contents)})"')
+        title = self.current_dir.split("/")[-1]
+        if title == "":
+            title = "Files"
+        file_count = len(self.dir_contents)
+        if file_count == 0:
+                self._write(f'p[2].b[11].txt="{title} (Empty)"')
+        else:
+            self._write(f'p[2].b[11].txt="{title} ({(self.files_page * page_size) + 1}-{min((self.files_page * page_size) + page_size, file_count)}/{file_count})"')
         component_index = 0
         for index in range(self.files_page * page_size, min(len(self.dir_contents), (self.files_page + 1) * page_size)):
             file = self.dir_contents[index]

--- a/display/display.py
+++ b/display/display.py
@@ -477,8 +477,6 @@ class DisplayController:
             "filament_switch_sensor fila": ["enabled"]
         }})
         data = ret["result"]["status"]
-        if "temperature" in data["heater_generic heater_bed_outer"] and data["heater_generic heater_bed_outer"]["temperature"] is not None:
-            self.printer_model = MODEL_PRO
         logger.info("Printer Model: " + str(self.printer_model))
         self.initialize_display()
         self.handle_status_update(data)

--- a/display/display.py
+++ b/display/display.py
@@ -187,14 +187,14 @@ class DisplayController:
                     # Strip the line and check if it contains "Starting Klippy..."
                     line = line.strip()
                     if "Restarting printer" in line or "Starting Klippy..." in line:
-                        print("Klipper is restarting.")
+                        logger.info("Klipper is restarting.")
                         self.klipper_restart_event.set()
                         # Add your desired action here for Klipper restart detection
 
         except FileNotFoundError:
-            print(f"Klipper log file not found at {log_file_path}.")
+            logger.error(f"Klipper log file not found at {log_file_path}.")
         except Exception as e:
-            print(f"Error while monitoring Klipper log: {e}")
+            logger.error(f"Error while monitoring Klipper log: {e}")
 
     def get_printer_model_from_file(self):
         try:
@@ -202,12 +202,12 @@ class DisplayController:
                 for line in file:
                     if line.startswith(tuple([MODEL_REGULAR, MODEL_PRO, MODEL_PLUS, MODEL_MAX])):
                         model_part = line.split('-')[0]
-                        print(f"Extracted Model: {model_part}")
+                        logger.info(f"Extracted Model: {model_part}")
                         return model_part
         except FileNotFoundError:
-            print("File not found")
+            logger.error("File not found")
         except Exception as e:
-            print(f"Error reading file: {e}")
+            logger.error(f"Error reading file: {e}")
         return None
 
     def get_device_name(self):


### PR DESCRIPTION
This PR fixes pausing/resuming/stopping/emergency stopping a print from the printing screen.

It also adds support for nested directories in the file picker and displays icons for files and folders to distinguish them. Filenames now strip the `.gcode` suffix to save screen space. Only gcode files are handled anyway so display the filetype is fairly useless.

Also changed some print statements to use the logger instead.