### PR TITLE
Update n4max-printer.cfg

### DIFF
--- a/printer-confs/n4max/n4max-printer.cfg
+++ b/printer-confs/n4max/n4max-printer.cfg
@@ -115,7 +115,7 @@ second_homing_speed: 3
 
 [tmc2209 stepper_x]
 uart_pin: PB9
-run_current: 1.2
+run_current: 1.0
 #hold_current: 0.8
 interpolate: True
 stealthchop_threshold: 999999
@@ -124,10 +124,10 @@ diag_pin:^PC0
 
 [tmc2209 stepper_y]
 uart_pin: PD2
-run_current: 1.5
+run_current: 1.4
 #hold_current: 1.2
 interpolate: True
-stealthchop_threshold: 999999
+stealthchop_threshold: 0
 driver_SGTHRS:110
 diag_pin:^PB8
 
@@ -290,18 +290,27 @@ gcode:
       AXIS_TWIST_COMPENSATION_CALIBRATE
 
 [screws_tilt_adjust]
-screw1_name: front left screw
-screw1: 56.75,12.05
-screw2_name: center left screw
-screw2: 56.75,189.05
-screw3_name: rear left screw
-screw3: 56.75,367.05
-screw4_name: rear right screw
-screw4: 409.75,367.05
-screw5_name: center right screw
-screw5: 409.75,189.05
-screw6_name: front right screw
-screw6: 409.75,12.05
+screw1: 239.75,194.55
+screw1_name: center point
+
+screw2: 56.75,12.05
+screw2_name: front left screw
+
+screw3: 56.75,189.05
+screw3_name: center left screw
+
+screw4: 56.75,367.05
+screw4_name: rear left screw
+
+screw5: 409.75,367.05
+screw5_name: rear right screw 
+
+screw6: 409.75,189.05
+screw6_name: center right screw
+
+screw7: 409.75,12.05
+screw7_name: front right screw
+
 horizontal_move_z: 10
 speed: 200
 screw_thread: CW-M4
@@ -328,9 +337,30 @@ gcode:
       G28
       TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM=58 MAXIMUM=65
       BED_MESH_CALIBRATE
+
+[bed_screws]
+screw1: 38, 34
+#screw1_name: front left screw
+screw2: 392, 34
+#screw2_name: front right screw
+screw3: 392, 210
+#screw3_name: side right screw
+screw4: 392, 388
+#screw4_name: rear right screw 
+screw5: 38, 388
+#screw5_name: rear left screw
+screw6: 38, 210
+#screw6_name: side left screw
+
+[gcode_macro Assisted_Leveling]
+gcode:
+      SET_HEATER_TEMPERATURE HEATER=heater_bed TARGET=60    
+      SET_HEATER_TEMPERATURE HEATER=extruder TARGET=160
+      G28
+      TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM=58 MAXIMUM=65
+      BED_SCREWS_ADJUST
+      TURN_OFF_HEATERS
       
-
-
 #####################################################################
 #   Probe
 #####################################################################


### PR DESCRIPTION
Motors: stepper y update, adjusted stepper x and y voltages, Levelling: screw tilt adjust - centre home position as a reference for 6-point levelling as it was was a bit off with centre point results are a bit better Bed screws & Assisted levelling macro for manual levelling for fast initial leveling