### PR TITLE
fix: MCU Alt Method on Trixie

### DIFF
--- a/mcu-firmware/alt-method/mcu-swflash-install.sh
+++ b/mcu-firmware/alt-method/mcu-swflash-install.sh
@@ -4,7 +4,7 @@
 SCRIPT_PATH="/usr/local/bin/gpio_set.sh"
 
 # Create and write the GPIO command to the script
-echo -e "#!/bin/bash\n/usr/bin/gpioset gpiochip1 14=0; /usr/bin/gpioset gpiochip1 15=0; sleep 0.5; /usr/bin/gpioset gpiochip1 15=1" | sudo tee "$SCRIPT_PATH" >/dev/null
+echo -e "#!/bin/bash\n/usr/bin/gpioset -t0 -c gpiochip1 14=0; /usr/bin/gpioset -t0 -c gpiochip1 15=0; sleep 0.5; /usr/bin/gpioset -t0 -c gpiochip1 15=1" | sudo tee "$SCRIPT_PATH" >/dev/null
 
 # Make the script executable
 sudo chmod +x "$SCRIPT_PATH"

--- a/mcu-firmware/alt-method/mcu-swflash-run.sh
+++ b/mcu-firmware/alt-method/mcu-swflash-run.sh
@@ -24,13 +24,13 @@ if [[ $create_backup == "y" ]]; then
     fi
     # Enable bootloader mode
     echo "Enabling bootloader mode..."
-    sudo gpioset gpiochip1 15=0
+    sudo gpioset -t0 -c gpiochip1 15=0
     sleep 0.5
-    sudo gpioset gpiochip1 14=1
+    sudo gpioset -t0 -c gpiochip1 14=1
     sleep 0.5
-    sudo gpioset gpiochip1 15=1
+    sudo gpioset -t0 -c gpiochip1 15=1
     sleep 0.5
-    sudo gpioset gpiochip1 14=0
+    sudo gpioset -t0 -c gpiochip1 14=0
     echo "Backing up current firmware to $BACKUP_FILE..."
     stm32flash -r "$BACKUP_FILE" -g 0x0 /dev/ttyS0
 else
@@ -39,20 +39,20 @@ fi
 
 # Enable bootloader mode again
 echo "Enabling bootloader mode..."
-sudo gpioset gpiochip1 15=0
+sudo gpioset -t0 -c gpiochip1 15=0
 sleep 0.5
-sudo gpioset gpiochip1 14=1
+sudo gpioset -t0 -c gpiochip1 14=1
 sleep 0.5
-sudo gpioset gpiochip1 15=1
+sudo gpioset -t0 -c gpiochip1 15=1
 sleep 0.5
-sudo gpioset gpiochip1 14=0
+sudo gpioset -t0 -c gpiochip1 14=0
 
 # Flash the new firmware
 echo "Flashing new firmware to STM32..."
 stm32flash -w ~/klipper/out/klipper.bin -v -S 0x08008000 -g 0x08000000 /dev/ttyS0
 
 echo "Flashing complete"
-gpioset gpiochip1 15=0; sleep 0.5; gpioset gpiochip1 15=1; sleep 1
+gpioset -t0 -c gpiochip1 15=0; sleep 0.5; gpioset -t0 -c gpiochip1 15=1; sleep 1
 # Starting the Klipper service
 echo "Starting the Klipper service..."
 sudo service klipper start


### PR DESCRIPTION
I've updated my printer to Trixie as a weekend project and noticed the MCU alt method wasn't working (had a lot of `gpioset: invalid line value: 'gpiochip1'` messages), mainly due to changes in how gpioset chip param should be provided (prefixed with `-c` or `--chip`) and for `gpioset` to be able to exit once called (the `-t0` part).

These changes allows it to boot fine and be able to flash the MCU directly as before.


Happy new year buddy!